### PR TITLE
Minor improvements to metrics explorer

### DIFF
--- a/phablytics/metrics/constants.py
+++ b/phablytics/metrics/constants.py
@@ -1,2 +1,16 @@
 DATE_FORMAT_YMD = '%Y-%m-%d'
 DATE_FORMAT_MDY_SHORT = '%b %d, %Y'
+
+INTERVAL_OPTIONS = [
+    'week',
+    'month',
+    'quarter',
+]
+DEFAULT_INTERVAL_OPTION = 'week'
+
+INTERVAL_DAYS_MAP = {
+    'week': 7,
+    'month': 30,
+    'quarter': 90,
+}
+DEFAULT_INTERVAL_DAYS = INTERVAL_DAYS_MAP[DEFAULT_INTERVAL_OPTION]

--- a/phablytics/web/metrics/forms.py
+++ b/phablytics/web/metrics/forms.py
@@ -12,7 +12,11 @@ from wtforms import (
 )
 
 # Phablytics Imports
-from phablytics.metrics.constants import DATE_FORMAT_YMD
+from phablytics.metrics.constants import (
+    DATE_FORMAT_YMD,
+    DEFAULT_INTERVAL_OPTION,
+    INTERVAL_OPTIONS,
+)
 from phablytics.settings import PROJECT_TEAM_NAMES
 from phablytics.utils import (
     end_of_month,
@@ -24,19 +28,10 @@ from phablytics.utils import (
 from phablytics.web.utils import format_choices
 
 
-INTERVAL_OPTIONS = [
-    'week',
-    'month',
-    'quarter',
-]
-DEFAULT_INTERVAL_OPTION = 'month'
-
-
 def get_filter_params():
     interval = request.args.get('interval', DEFAULT_INTERVAL_OPTION)
 
     today = datetime.date.today()
-
 
     if interval == 'month':
         period_end_default = end_of_month(today)
@@ -45,6 +40,7 @@ def get_filter_params():
         period_end_default = end_of_quarter(today)
         period_start_default = start_of_quarter(period_end_default - datetime.timedelta(days=360))
     else:
+        # `interval == 'week'` or unspecified
         last_month = today - datetime.timedelta(days=31)
         tomorrow = today + datetime.timedelta(days=1)
 

--- a/phablytics/web/templates/explore/explore.html
+++ b/phablytics/web/templates/explore/explore.html
@@ -17,7 +17,7 @@
             {# Subsegments #}
             {% for subsegment in segment.segments %}
             <li>
-              <a href="/metrics/alltasks?interval=quarter&projects={{ subsegment.projects_str }}">
+              <a href="/metrics/alltasks?projects={{ subsegment.projects_str }}">
                 {{ subsegment.name }}
               </a>
             </li>
@@ -26,7 +26,7 @@
             {# Regular Projects #}
             {% for project in segment.projects %}
             <li>
-              <a href="/metrics/alltasks?interval=quarter&projects={{ project.name }}">
+              <a href="/metrics/alltasks?projects={{ project.name }}">
                 {{ project.name }}
               </a>
             </li>


### PR DESCRIPTION
- consistently sets default value for interval to `week` (was: `quarter` (form) or `month` (UI))
- converts TaskMetric from `namedtuple` base class to `dataclass`